### PR TITLE
Add user_data property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Attribute Name                 Contents
 ``public_ipv4``                The public IPv4 address of the instance, e.g. ``'1.2.3.4'``
 ``region``                     The region the instance is running in, e.g. ``'eu-west-1'``
 ``reservation_id``             The ID of the reservation used to launch the instance, e.g. ``'r-12345678901234567'``
+``user_data``                  The raw user_data of the instance
 ============================== ========
 
 These values should all be safe to cache for the lifetime of your Python

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -6,14 +6,15 @@ from cached_property import cached_property
 
 __author__ = 'Adam Johnson'
 __email__ = 'me@adamj.eu'
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 __all__ = ('ec2_metadata',)
 
 
-SERVICE_URL = 'http://169.254.169.254/2016-09-02/'
+SERVICE_URL = 'http://169.254.169.254/latest/'
 DYNAMIC_URL = SERVICE_URL + 'dynamic/'
 METADATA_URL = SERVICE_URL + 'meta-data/'
+USERDATA_URL = SERVICE_URL + 'user-data/'
 
 
 class EC2Metadata(object):
@@ -82,6 +83,10 @@ class EC2Metadata(object):
     @cached_property
     def reservation_id(self):
         return requests.get(METADATA_URL + 'reservation-id').text
+
+    @cached_property
+    def user_data(self):
+        return requests.get(USERDATA_URL).text
 
 
 ec2_metadata = EC2Metadata()


### PR DESCRIPTION
boto2 also had a boto.utils.get_instance_userdata() that is not available in boto3

I added it as a new property, using the userdata url provided by aws.

I needed this as I store json configuration for some of my boot/services scripts.