### PR TITLE
Add security_groups attribute

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending Release
 ---------------
 
 .. Insert new release notes below this line
+* Add security groups attribute.
 
 1.0.0 (2017-06-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Pending Release
 
 .. Insert new release notes below this line
 
-* Add security groups attribute.
+* Add ``security_groups`` attribute.
 
 1.0.0 (2017-06-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending Release
 ---------------
 
 .. Insert new release notes below this line
+
 * Add security groups attribute.
 
 1.0.0 (2017-06-16)

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Attribute Name                 Contents
 ``public_ipv4``                The public IPv4 address of the instance, e.g. ``'1.2.3.4'``
 ``region``                     The region the instance is running in, e.g. ``'eu-west-1'``
 ``reservation_id``             The ID of the reservation used to launch the instance, e.g. ``'r-12345678901234567'``
+``security_groups``            List of security groups by name, e.g. ``['ssh-access', 'custom-sg-1']'``
 ============================== ========
 
 These values should all be safe to cache for the lifetime of your Python

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -83,5 +83,10 @@ class EC2Metadata(object):
     def reservation_id(self):
         return requests.get(METADATA_URL + 'reservation-id').text
 
+    @cached_property
+    def security_groups(self):
+        # since this can be one or more items, always return as an array.
+        return requests.get(METADATA_URL + 'security-groups').text.splitlines()
+
 
 ec2_metadata = EC2Metadata()

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -85,7 +85,6 @@ class EC2Metadata(object):
 
     @cached_property
     def security_groups(self):
-        # since this can be one or more items, always return as an array.
         return requests.get(METADATA_URL + 'security-groups').text.splitlines()
 
 

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -140,20 +140,20 @@ def test_reservation_id(resps):
     assert ec2_metadata.reservation_id == 'r-12345678901234567'
 
 
-def test_security_groups(resps):
+def test_security_groups_single(resps):
     # most common case: a single SG
     add_response(resps, 'security-groups', 'security-group-one')
     assert ec2_metadata.security_groups == ['security-group-one']
+
+
+def test_security_groups_two(resps):
     # another common case: multiple SGs
-    ec2_metadata.clear_all()
     add_response(resps, 'security-groups', "security-group-one\nsecurity-group-2")
     assert ec2_metadata.security_groups == ['security-group-one', 'security-group-2']
+
+
+def test_security_groups_emptystring(resps):
     # check '' too. Can't create an instance without a SG but we should safely handle it,
     # perhaps it's possible in OpenStack.
-    ec2_metadata.clear_all()
     add_response(resps, 'security-groups', '')
-    assert ec2_metadata.security_groups == []
-    # finally, check None
-    ec2_metadata.clear_all()
-    add_response(resps, 'security-groups', text=None)
     assert ec2_metadata.security_groups == []

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -139,6 +139,7 @@ def test_reservation_id(resps):
     add_response(resps, 'reservation-id', 'r-12345678901234567')
     assert ec2_metadata.reservation_id == 'r-12345678901234567'
 
+
 def test_security_groups(resps):
     # most common case: a single SG
     add_response(resps, 'security-groups', 'security-group-one')
@@ -154,5 +155,5 @@ def test_security_groups(resps):
     assert ec2_metadata.security_groups == []
     # finally, check None
     ec2_metadata.clear_all()
-    add_response(resps, 'security-groups', None)
+    add_response(resps, 'security-groups', text=None)
     assert ec2_metadata.security_groups == []

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -138,3 +138,21 @@ def test_region(resps):
 def test_reservation_id(resps):
     add_response(resps, 'reservation-id', 'r-12345678901234567')
     assert ec2_metadata.reservation_id == 'r-12345678901234567'
+
+def test_security_groups(resps):
+    # most common case: a single SG
+    add_response(resps, 'security-groups', 'security-group-one')
+    assert ec2_metadata.security_groups == ['security-group-one']
+    # another common case: multiple SGs
+    ec2_metadata.clear_all()
+    add_response(resps, 'security-groups', "security-group-one\nsecurity-group-2")
+    assert ec2_metadata.security_groups == ['security-group-one', 'security-group-2']
+    # check '' too. Can't create an instance without a SG but we should safely handle it,
+    # perhaps it's possible in OpenStack.
+    ec2_metadata.clear_all()
+    add_response(resps, 'security-groups', '')
+    assert ec2_metadata.security_groups == []
+    # finally, check None
+    ec2_metadata.clear_all()
+    add_response(resps, 'security-groups', None)
+    assert ec2_metadata.security_groups == []


### PR DESCRIPTION
This is slightly different because it's "groups", not "group". I've covered the likely scenarios in the tests, as well as the cases that shouldn't happen ('' and None).