### PR TITLE
Make network_interfaces return a dict of NetworkInterface objects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
-* Add ``network``` attribute.
+* Add ``network_interfaces`` attribute which is a list of ``NetworkInterface``
+  instances, which have many attributes themselves.
 
 1.1.0 (2017-08-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -42,50 +42,236 @@ been ported to ``boto3``, as per `this issue
 building a new version inside ``boto3`` it would work well as a standalone
 library.
 
-Usage
-=====
+API
+===
 
-There is a special singleton object in the module to import:
+``EC2Metadata``
+---------------
 
-.. code-block:: python
-
-    from ec2_metadata import ec2_metadata
-
-This object has a number of lazy attributes that pull the respective data from
-the metadata service on first access, all documented below. They are all
-strings (Python 3 ``str``) except where noted.
-
+A container that represents the data available on the EC2 metadata service.
 Attributes don't entirely correspond to the paths in the metadata service -
 they have been 'cleaned up'. You may also want to refer to the `metadata
 service docs
 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories>`_
 to understand the exact contents.
 
-============================== ========
-Attribute Name                 Contents
-============================== ========
-``account_id``                 The current AWS account ID, e.g. ``'123456789012'``
-``ami_id``                     The ID of the AMI used to launch the instance, e.g. ``'ami-123456'``
-``availability_zone``          The name of the current AZ e.g. ``'eu-west-1a'``
-``ami_launch_index``           The index of the instance in the launch request, zero-based, e.g. ``0``
-``ami_manifest_path``          The path to the AMI manifest file in Amazon S3, or ``'(unknown)'`` on EBS-backed AMI's
-``instance_id``                The current instance's ID, e.g. ``'i-123456'``
-``instance_identity_document`` A dictionary of dynamic data, see `AWS docs <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html>`_
-``instance_type``              The current instance's type, e.g. ``'t2.nano'``
-``mac``                        The instance's MAC address, e.g. ``'0a:d2:ae:4d:f3:12'``
-``network``                    A nested dictionary of network interfaces and their parameters.
-``private_hostname``           The private IPv4 DNS hostname of the instance, e.g. ``'ip-172-30-0-0.eu-west-1.compute.internal'``
-``private_ipv4``               The private IPv4 of the instance, e.g. ``'172.30.0.0'``
-``public_hostname``            The public DNS hostname of the instance, e.g. ``'ec2-1-2-3-4.compute-1.amazonaws.com'``
-``public_ipv4``                The public IPv4 address of the instance, e.g. ``'1.2.3.4'``
-``region``                     The region the instance is running in, e.g. ``'eu-west-1'``
-``reservation_id``             The ID of the reservation used to launch the instance, e.g. ``'r-12345678901234567'``
-``security_groups``            List of security groups by name, e.g. ``['ssh-access', 'custom-sg-1']``
-``user_data`` (``bytes``)      The raw user data assigned to the instance (not base64 encoded), or ``None`` if there is none.
-============================== ========
+There's a singleton instance of it at the name ``ec2_metadata`` which should
+cover 90% of use cases. Use it like:
 
-These values should all be safe to cache for the lifetime of your Python
-process, since they are (nearly entirely) immutable (some things can change,
-e.g. ``public_ipv4`` when you attach an Elastic IP to the instance). If you
-need to flush the caching, you can call ``ec2_metadata.clear_all()`` to wipe it
-all.
+.. code-block:: python
+
+    from ec2_metadata import ec2_metadata
+    ec2_metadata.region
+
+All the attributes cache on first access, since they are mostly immutable, or
+at least require an instance stop to change, however some properties like
+network interfaces can change over the lifetime of an instance. If you want to
+clear the cache of one attribute you can just `del` it:
+
+.. code-block:: python
+
+    del ec2_metadata.network_interfaces
+
+To clear all, use the ``clear_all()`` method as per below.
+
+
+``account_id: str``
+~~~~~~~~~~~~~~~~~~~
+
+The current AWS account ID, e.g. ``'123456789012'``.
+
+``ami_id: str``
+~~~~~~~~~~~~~~~
+
+The ID of the AMI used to launch the instance, e.g. ``'ami-123456'``.
+
+``availability_zone: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The name of the current AZ e.g. ``'eu-west-1a'``.
+
+``ami_launch_index: int``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The index of the instance in the launch request, zero-based, e.g. ``0``.
+
+``ami_manifest_path: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The path to the AMI manifest file in Amazon S3, or ``'(unknown)'`` on
+EBS-backed AMI's.
+
+``clear_all() -> None``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Clear all the cached attributes on the class, meaning their next access will
+re-fetch the data from the metadata API.
+
+``instance_id: str``
+~~~~~~~~~~~~~~~~~~~~
+
+The current instance's ID, e.g. ``'i-123456'``
+
+``instance_identity_document: dict``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary of dynamic data - see `AWS docs
+<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html>`_.
+
+``instance_type: str``
+~~~~~~~~~~~~~~~~~~~~~~
+
+The current instance's type, e.g. ``'t2.nano'``
+
+``mac: str``
+~~~~~~~~~~~~
+
+The instance's MAC address, e.g. ``'0a:d2:ae:4d:f3:12'``
+
+``network_interfaces: Dict[str, NetworkInterface]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary of mac address to ``NetworkInterface``, which represents the data
+available on a network interface - see below. E.g.
+``{'01:23:45:67:89:ab': NetworkInterface('01:23:45:67:89:ab')}``
+
+``private_hostname: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The private IPv4 DNS hostname of the instance, e.g.
+``'ip-172-30-0-0.eu-west-1.compute.internal'`` .
+
+``private_ipv4: str``
+~~~~~~~~~~~~~~~~~~~~~
+
+The private IPv4 of the instance, e.g. ``'172.30.0.0'``.
+
+``public_hostname: str``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The public DNS hostname of the instance, e.g.
+``'ec2-1-2-3-4.compute-1.amazonaws.com'``.
+
+``public_ipv4: str``
+~~~~~~~~~~~~~~~~~~~~
+
+The public IPv4 address of the instance, e.g.
+``'1.2.3.4'``.
+
+``region: str``
+~~~~~~~~~~~~~~~
+
+The region the instance is running in, e.g. ``'eu-west-1'``.
+
+``reservation_id: str``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ID of the reservation used to launch the instance, e.g.
+``'r-12345678901234567'``.
+
+``security_groups: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List of security groups by name, e.g.
+``['ssh-access', 'custom-sg-1']``.
+
+``user_data: bytes``
+~~~~~~~~~~~~~~~~~~~~
+
+The raw user data assigned to the instance (not base64 encoded), or ``None`` if
+there is none.
+
+``NetworkInterface``
+--------------------
+
+Represents a single network interface, as retrieved from
+``EC2Metadata.network_interfaces``. Again like ``EC2Metadata`` all its
+attributes cache on first access, and can be cleared with ``del`` or
+its ``clear_all()`` method.
+
+``device_number: int``
+~~~~~~~~~~~~~~~~~~~~~~
+
+The unique device number associated with that interface, e.g. ``0``.
+
+``ipv4_associations: Dict[str, List[str]]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary mapping public IP addresses on the interface to the list of
+private IP addresses associated with that public IP, for each public IP that is
+associated with the interface, e.g. ``{'54.0.0.1': ['172.30.0.0']}``.
+
+``mac: str``
+~~~~~~~~~~~~
+
+The MAC address of the interface, e.g. ``'01:23:45:67:89:ab'``.
+
+``owner_id: str``
+~~~~~~~~~~~~~~~~~
+
+The AWS Account ID of the owner of the network interface, e.g.
+``'123456789012'``.
+
+``private_hostname: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The interface's local/private hostname, e.g.
+``'ip-172-30-0-0.eu-west-1.compute.internal'``.
+
+``private_ipv4s: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The private IPv4 addresses associated with the interface, e.g.
+``['172.30.0.0']``.
+
+``public_hostname: str``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The interface's public DNS (IPv4), e.g.
+``'ec2-54-0-0-0.compute-1.amazonaws.com'``.
+
+``public_ipv4s: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Elastic IP addresses associated with the interface, e.g. ``['54.0.0.0']``.
+
+``security_groups: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The names of the security groups to which the network interface belongs, e.g.
+``['ssh-access', 'custom-sg-1']``.
+
+``security_group_ids: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The names of the security groups to which the network interface belongs, e.g.
+``['sg-12345678', 'sg-12345679']``.
+
+``subnet_id: str``
+~~~~~~~~~~~~~~~~~~
+
+The ID of the subnet in which the interface resides, e.g.
+``'subnet-12345678'``.
+
+``subnet_ipv4_cidr_block: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The IPv4 CIDR block of the subnet in which the interface resides, e.g.
+``'172.30.0.0/24'``.
+
+``vpc_id: str``
+~~~~~~~~~~~~~~~
+
+The ID of the VPC in which the interface resides, e.g. ``'vpc-12345678'``.
+
+``vpc_ipv4_cidr_block: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The IPv4 CIDR block of the VPC, or ``None`` if the instance isn't in a VPC,
+e.g. ``'172.30.0.0/16'``.
+
+``vpc_ipv4_cidr_blocks: List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The list of IPv4 CIDR blocks, or ``None`` if the instance isn't in a VPC, e.g.
+``['172.30.0.0/16']``.

--- a/README.rst
+++ b/README.rst
@@ -172,8 +172,7 @@ The ID of the reservation used to launch the instance, e.g.
 ``security_groups: List[str]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-List of security groups by name, e.g.
-``['ssh-access', 'custom-sg-1']``.
+List of security groups by name, e.g. ``['ssh-access', 'custom-sg-1']``.
 
 ``user_data: bytes``
 ~~~~~~~~~~~~~~~~~~~~

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -68,7 +68,7 @@ class EC2Metadata(BaseLazyObject):
     @cached_property
     def network_interfaces(self):
         macs_text = requests.get(METADATA_URL + 'network/interfaces/macs/').text
-        macs = [line.rstrip('/') for line in macs_text.split('\n')]
+        macs = [line.rstrip('/') for line in macs_text.splitlines()]
         return {mac: NetworkInterface(mac) for mac in macs}
 
     @cached_property
@@ -140,13 +140,23 @@ class NetworkInterface(BaseLazyObject):
             associations[private_ip] = public_ip
         return associations
 
+    # No IPV6 instances at hand to test this on, so I only know you get 404 in
+    # case there are none
+    # @cached_property
+    # def ipv6s(self):
+    #     pass
+
+    @cached_property
+    def owner_id(self):
+        return requests.get(self._url('owner-id')).text
+
     @cached_property
     def private_hostname(self):
         return requests.get(self._url('local-hostname')).text
 
     @cached_property
     def private_ipv4s(self):
-        return requests.get(self._url('local-ipv4s')).text.split('\n')
+        return requests.get(self._url('local-ipv4s')).text.splitlines()
 
     @cached_property
     def public_hostname(self):
@@ -154,7 +164,15 @@ class NetworkInterface(BaseLazyObject):
 
     @cached_property
     def public_ipv4s(self):
-        return requests.get(self._url('public-ipv4s')).text.split('\n')
+        return requests.get(self._url('public-ipv4s')).text.splitlines()
+
+    @cached_property
+    def security_groups(self):
+        return requests.get(self._url('security-groups')).text.splitlines()
+
+    @cached_property
+    def security_group_ids(self):
+        return requests.get(self._url('security-group-ids')).text.splitlines()
 
     @cached_property
     def subnet_id(self):

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -19,12 +19,15 @@ METADATA_URL = SERVICE_URL + 'meta-data/'
 USERDATA_URL = SERVICE_URL + 'user-data/'
 
 
-class EC2Metadata(object):
+class BaseLazyObject(object):
 
     def clear_all(self):
         for key in tuple(self.__dict__.keys()):
             if isinstance(getattr(self.__class__, key), cached_property):
                 del self.__dict__[key]
+
+
+class EC2Metadata(BaseLazyObject):
 
     @property
     def account_id(self):
@@ -63,26 +66,10 @@ class EC2Metadata(object):
         return requests.get(METADATA_URL + 'mac').text
 
     @cached_property
-    def network(self):
-        '''The network interface map is keyed by MAC address. This structure will
-           be returned like how it is given in the metadata interface.'''
-        return self.recursive_get_data(METADATA_URL, 'network/interfaces/macs/')
-
-    # helper function, not really designed to be called directly by clients.
-    # this works by recognizing that value-only keys don't have a trailing slash,
-    # and keys with a trailing slash have subkeys.
-    def recursive_get_data(self, baseurl, key):
-        curr_url = baseurl + key
-        if not key.endswith('/'):  # don't explore further, just fetch
-            return requests.get(curr_url).text
-
-        # trailing slash, need to explore further
-        ret = {}
-        for l in requests.get(curr_url).text.splitlines():
-            lkey = l.rstrip('/')
-            ret[lkey] = self.recursive_get_data(curr_url, l)
-
-        return ret
+    def network_interfaces(self):
+        macs_text = requests.get(METADATA_URL + 'network/interfaces/macs/').text
+        macs = [line.rstrip('/') for line in macs_text.split('\n')]
+        return {mac: NetworkInterface(mac) for mac in macs}
 
     @cached_property
     def private_hostname(self):
@@ -119,6 +106,41 @@ class EC2Metadata(object):
             return None
         else:
             return resp.content
+
+
+class NetworkInterface(BaseLazyObject):
+
+    def __init__(self, mac):
+        self.mac = mac
+
+    def __repr__(self):
+        return 'NetworkInterface({mac})'.format(mac=repr(self.mac))
+
+    def __eq__(self, other):
+        return isinstance(other, NetworkInterface) and self.mac == other.mac
+
+    def _url(self, item):
+        return '{base}network/interfaces/macs/{mac}/{item}'.format(
+            base=METADATA_URL,
+            mac=self.mac,
+            item=item
+        )
+
+    @cached_property
+    def device_number(self):
+        return int(requests.get(self._url('device-number')).text)
+
+    @cached_property
+    def private_hostname(self):
+        return requests.get(self._url('local-hostname')).text
+
+    @cached_property
+    def private_ipv4s(self):
+        return requests.get(self._url('local-ipv4s')).text.split('\n')
+
+    @cached_property
+    def subnet_id(self):
+        return requests.get(self._url('subnet-id')).text
 
 
 ec2_metadata = EC2Metadata()

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -178,5 +178,45 @@ class NetworkInterface(BaseLazyObject):
     def subnet_id(self):
         return requests.get(self._url('subnet-id')).text
 
+    @cached_property
+    def subnet_ipv4_cidr_block(self):
+        resp = requests.get(self._url('subnet-ipv4-cidr-block'))
+        if resp.status_code == 404:
+            return None
+        else:
+            return resp.text
+
+    # No IPV6 instances at hand to test this on, so I only know you get 404 in
+    # case there are none
+    # @cached_property
+    # def subnet_ipv6_cidr_blocks(self):
+    #     pass
+
+    @cached_property
+    def vpc_id(self):
+        return requests.get(self._url('vpc-id')).text
+
+    @cached_property
+    def vpc_ipv4_cidr_block(self):
+        resp = requests.get(self._url('vpc-ipv4-cidr-block'))
+        if resp.status_code == 404:
+            return None
+        else:
+            return resp.text
+
+    @cached_property
+    def vpc_ipv4_cidr_blocks(self):
+        resp = requests.get(self._url('vpc-ipv4-cidr-blocks'))
+        if resp.status_code == 404:
+            return []
+        else:
+            return resp.text.splitlines()
+
+    # No IPV6 at hand to test this on, so I only know you get 404 in case there
+    # are none
+    # @cached_property
+    # def vpc_ipv6_cidr_blocks(self):
+    #     pass
+
 
 ec2_metadata = EC2Metadata()

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -133,11 +133,11 @@ class NetworkInterface(BaseLazyObject):
     @cached_property
     def ipv4_associations(self):
         associations = {}
-        for private_ip in self.public_ipv4s:
-            resp = requests.get(self._url('ipv4-associations/{}'.format(private_ip)))
+        for public_ip in self.public_ipv4s:
+            resp = requests.get(self._url('ipv4-associations/{}'.format(public_ip)))
             resp.raise_for_status()
-            public_ip = resp.text
-            associations[private_ip] = public_ip
+            private_ips = resp.text.splitlines()
+            associations[public_ip] = private_ips
         return associations
 
     # No IPV6 instances at hand to test this on, so I only know you get 404 in

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -131,12 +131,30 @@ class NetworkInterface(BaseLazyObject):
         return int(requests.get(self._url('device-number')).text)
 
     @cached_property
+    def ipv4_associations(self):
+        associations = {}
+        for private_ip in self.public_ipv4s:
+            resp = requests.get(self._url('ipv4-associations/{}'.format(private_ip)))
+            resp.raise_for_status()
+            public_ip = resp.text
+            associations[private_ip] = public_ip
+        return associations
+
+    @cached_property
     def private_hostname(self):
         return requests.get(self._url('local-hostname')).text
 
     @cached_property
     def private_ipv4s(self):
         return requests.get(self._url('local-ipv4s')).text.split('\n')
+
+    @cached_property
+    def public_hostname(self):
+        return requests.get(self._url('public-hostname')).text
+
+    @cached_property
+    def public_ipv4s(self):
+        return requests.get(self._url('public-ipv4s')).text.split('\n')
 
     @cached_property
     def subnet_id(self):

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 cached-property
-docutils
+# docutils - removed due to unfixable "Duplicate implicit target name"
 flake8
 modernize
 multilint
-pygments
+# pygments - removed due to unfixable "Duplicate implicit target name"
 pytest
 pytest-cov
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ chardet==3.0.4            # via requests
 configparser==3.5.0       # via flake8
 cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
-docutils==0.14
 enum34==1.1.6             # via flake8
 flake8==3.4.1
 funcsigs==1.0.2           # via mock
@@ -23,7 +22,6 @@ pbr==3.1.1                # via mock
 py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
-pygments==2.2.0
 pytest-cov==2.5.1
 pytest==3.2.1
 requests==2.18.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ not_skip = __init__.py
 
 [tool:multilint]
 paths = ec2_metadata.py
-        setup.py
         test_ec2_metadata.py
 
 [tool:pytest]

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -185,7 +185,7 @@ def test_user_data_something(resps):
 
 # NetworkInterface tests
 
-def add_interface_response(resps, url, text, **kwargs):
+def add_interface_response(resps, url, text='', **kwargs):
     full_url = METADATA_URL + 'network/interfaces/macs/' + example_mac + url
     resps.add(responses.GET, full_url, body=text, **kwargs)
 
@@ -259,3 +259,38 @@ def test_network_interface_security_group_ids(resps):
 def test_network_interface_subnet_id(resps):
     add_interface_response(resps, '/subnet-id', 'subnet-12345678')
     assert NetworkInterface(example_mac).subnet_id == 'subnet-12345678'
+
+
+def test_network_interface_subnet_ipv4_cidr_block(resps):
+    add_interface_response(resps, '/subnet-ipv4-cidr-block', '172.30.0.0/24')
+    assert NetworkInterface(example_mac).subnet_ipv4_cidr_block == '172.30.0.0/24'
+
+
+def test_network_interface_subnet_ipv4_cidr_block_none(resps):
+    add_interface_response(resps, '/subnet-ipv4-cidr-block', status=404)
+    assert NetworkInterface(example_mac).subnet_ipv4_cidr_block is None
+
+
+def test_network_interface_vpc_id(resps):
+    add_interface_response(resps, '/vpc-id', 'vpc-12345678')
+    assert NetworkInterface(example_mac).vpc_id == 'vpc-12345678'
+
+
+def test_network_interface_vpc_ipv4_cidr_block(resps):
+    add_interface_response(resps, '/vpc-ipv4-cidr-block', '172.30.0.0/16')
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_block == '172.30.0.0/16'
+
+
+def test_network_interface_vpc_ipv4_cidr_block_none(resps):
+    add_interface_response(resps, '/vpc-ipv4-cidr-block', status=404)
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_block is None
+
+
+def test_network_interface_vpc_ipv4_cidr_blocks(resps):
+    add_interface_response(resps, '/vpc-ipv4-cidr-blocks', '172.30.0.0/16')
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_blocks == ['172.30.0.0/16']
+
+
+def test_network_interface_vpc_ipv4_cidr_blocks_none(resps):
+    add_interface_response(resps, '/vpc-ipv4-cidr-blocks', status=404)
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_blocks == []

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -216,8 +216,8 @@ def test_network_interface_ipv4_associations(resps):
     add_interface_response(resps, '/ipv4-associations/54.0.0.0', '172.30.0.0')
     add_interface_response(resps, '/ipv4-associations/54.0.0.1', '172.30.0.1')
     assert NetworkInterface(example_mac).ipv4_associations == {
-        '54.0.0.0': '172.30.0.0',
-        '54.0.0.1': '172.30.0.1',
+        '54.0.0.0': ['172.30.0.0'],
+        '54.0.0.1': ['172.30.0.1'],
     }
 
 

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -221,6 +221,11 @@ def test_network_interface_ipv4_associations(resps):
     }
 
 
+def test_network_interface_owner_id(resps):
+    add_interface_response(resps, '/owner-id', '123456789012')
+    assert NetworkInterface(example_mac).owner_id == '123456789012'
+
+
 def test_network_interface_private_hostname(resps):
     add_interface_response(resps, '/local-hostname', 'ip-172-30-0-0.eu-west-1.compute.internal')
     assert NetworkInterface(example_mac).private_hostname == 'ip-172-30-0-0.eu-west-1.compute.internal'
@@ -239,6 +244,16 @@ def test_network_interface_public_hostname(resps):
 def test_network_interface_public_ipv4s(resps):
     add_interface_response(resps, '/public-ipv4s', '54.0.0.0\n54.0.0.1')
     assert NetworkInterface(example_mac).public_ipv4s == ['54.0.0.0', '54.0.0.1']
+
+
+def test_network_interface_security_groups(resps):
+    add_interface_response(resps, '/security-groups', 'foo\nbar')
+    assert NetworkInterface(example_mac).security_groups == ['foo', 'bar']
+
+
+def test_network_interface_security_group_ids(resps):
+    add_interface_response(resps, '/security-group-ids', 'sg-12345678\nsg-12345679')
+    assert NetworkInterface(example_mac).security_group_ids == ['sg-12345678', 'sg-12345679']
 
 
 def test_network_interface_subnet_id(resps):

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -211,6 +211,16 @@ def test_network_interface_device_number(resps):
     assert NetworkInterface(example_mac).device_number == 0
 
 
+def test_network_interface_ipv4_associations(resps):
+    add_interface_response(resps, '/public-ipv4s', '54.0.0.0\n54.0.0.1')
+    add_interface_response(resps, '/ipv4-associations/54.0.0.0', '172.30.0.0')
+    add_interface_response(resps, '/ipv4-associations/54.0.0.1', '172.30.0.1')
+    assert NetworkInterface(example_mac).ipv4_associations == {
+        '54.0.0.0': '172.30.0.0',
+        '54.0.0.1': '172.30.0.1',
+    }
+
+
 def test_network_interface_private_hostname(resps):
     add_interface_response(resps, '/local-hostname', 'ip-172-30-0-0.eu-west-1.compute.internal')
     assert NetworkInterface(example_mac).private_hostname == 'ip-172-30-0-0.eu-west-1.compute.internal'
@@ -219,6 +229,16 @@ def test_network_interface_private_hostname(resps):
 def test_network_interface_private_ipv4s(resps):
     add_interface_response(resps, '/local-ipv4s', '172.30.0.0\n172.30.0.1')
     assert NetworkInterface(example_mac).private_ipv4s == ['172.30.0.0', '172.30.0.1']
+
+
+def test_network_interface_public_hostname(resps):
+    add_interface_response(resps, '/public-hostname', '')
+    assert NetworkInterface(example_mac).public_hostname == ''
+
+
+def test_network_interface_public_ipv4s(resps):
+    add_interface_response(resps, '/public-ipv4s', '54.0.0.0\n54.0.0.1')
+    assert NetworkInterface(example_mac).public_ipv4s == ['54.0.0.0', '54.0.0.1']
 
 
 def test_network_interface_subnet_id(resps):


### PR DESCRIPTION
Each NetworkInterface then caches its associated attributes, avoiding lots of upfront fetching.

Also rewrite the docs to make them clear for this number of attributes.