### PR TITLE
Fix README rst so it will render on PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,7 +20,8 @@ Pending Release
 1.2.1 (2017-08-31)
 ------------------
 
-* Make ``public_*`` properties return ``None` for instances that aren't public.
+* Make ``public_*`` properties return ``None`` for instances that aren't
+  public.
 
 1.2.0 (2017-08-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,8 @@ A dictionary of dynamic data - see `AWS docs
 
 The current instance's type, e.g. ``'t2.nano'``
 
-``mac: str``
-~~~~~~~~~~~~
+``mac : str``
+~~~~~~~~~~~~~
 
 The instance's MAC address, e.g. ``'0a:d2:ae:4d:f3:12'``
 
@@ -138,8 +138,8 @@ A dictionary of mac address to ``NetworkInterface``, which represents the data
 available on a network interface - see below. E.g.
 ``{'01:23:45:67:89:ab': NetworkInterface('01:23:45:67:89:ab')}``
 
-``private_hostname: str``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``private_hostname : str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The private IPv4 DNS hostname of the instance, e.g.
 ``'ip-172-30-0-0.eu-west-1.compute.internal'`` .
@@ -149,8 +149,8 @@ The private IPv4 DNS hostname of the instance, e.g.
 
 The private IPv4 of the instance, e.g. ``'172.30.0.0'``.
 
-``public_hostname: str``
-~~~~~~~~~~~~~~~~~~~~~~~~
+``public_hostname : str``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The public DNS hostname of the instance, or ``None`` if the instance is not
 public, e.g. ``'ec2-1-2-3-4.compute-1.amazonaws.com'``.
@@ -172,8 +172,8 @@ The region the instance is running in, e.g. ``'eu-west-1'``.
 The ID of the reservation used to launch the instance, e.g.
 ``'r-12345678901234567'``.
 
-``security_groups: List[str]``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``security_groups : List[str]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 List of security groups by name, e.g. ``['ssh-access', 'custom-sg-1']``.
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 cached-property
-# docutils - removed due to unfixable "Duplicate implicit target name"
+docutils
 flake8
 modernize
 multilint
-# pygments - removed due to unfixable "Duplicate implicit target name"
+pygments
 pytest
 pytest-cov
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ chardet==3.0.4            # via requests
 configparser==3.5.0       # via flake8
 cookies==2.2.1            # via responses
 coverage==4.4.1           # via pytest-cov
+docutils==0.14
 enum34==1.1.6             # via flake8
 flake8==3.4.1
 funcsigs==1.0.2           # via mock
@@ -22,6 +23,7 @@ pbr==3.1.1                # via mock
 py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
+pygments==2.2.0
 pytest-cov==2.5.1
 pytest==3.2.3
 requests==2.18.4


### PR DESCRIPTION
Workaround the 'Duplicate implicit target name' warning from setup.py check
by subtly changing the titles. A genuine error that was missed has been fixed
too.