### PR TITLE
Use timeout of 1 second for requests to the metadata API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Use timeout of 1 second for requests to the metadata API.
+
 1.7.1 (2018-09-17)
 ------------------
 

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -35,7 +35,7 @@ class EC2Metadata(BaseLazyObject):
         self._session = session
 
     def _get_url(self, url, allow_404=False):
-        resp = self._session.get(url)
+        resp = self._session.get(url, timeout=1.0)
         if resp.status_code != 404 or not allow_404:
             resp.raise_for_status()
         return resp


### PR DESCRIPTION
Fixes #85. This default should be generous and we'll add a way of overriding it if anyone complains, but it's unlikely they will.