### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 1.8.0 (2018-10-21)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Use **pip**:
 
     pip install ec2-metadata
 
-Tested on Python versions 2.7 and 3.7.
+Python 3.4+ supported.
 
 Why?
 ====

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import requests
 from cached_property import cached_property
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,9 +2,7 @@ cached-property
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
-modernize
 multilint
 pygments
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,21 +9,15 @@ attrs==18.2.0             # via pytest
 cached-property==1.5.1
 certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
-configparser==3.7.1       # via flake8
 coverage==4.5.2           # via pytest-cov
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 idna==2.8                 # via requests
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -33,6 +27,5 @@ pytest-cov==2.6.1
 pytest==4.1.1
 requests-mock==1.5.2
 requests==2.21.0
-scandir==1.9.0            # via pathlib2
-six==1.12.0               # via more-itertools, multilint, pathlib2, pytest, requests-mock
+six==1.12.0               # via more-itertools, multilint, pytest, requests-mock
 urllib3==1.24.1           # via requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@ universal = 1
 max_line_length = 120
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 include_trailing_comma = True
 known_first_party = ec2_metadata
 line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -16,10 +12,10 @@ def get_version(filename):
 version = get_version('ec2_metadata.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -37,7 +33,7 @@ setup(
         'cached-property',
         'requests',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license='ISC License',
     zip_safe=False,
     keywords='AWS, EC2, metadata',
@@ -47,8 +43,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 import requests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,12 @@
 [tox]
 envlist =
-    py{27,3},
-    py{27,3}-codestyle
+    py3,
+    py3-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
-
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires` and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin and `modernize`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports