### PR TITLE
Stop building universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max_line_length = 120
 


### PR DESCRIPTION
Missed when removing Python 2 support.