### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ ec2-metadata
 .. image:: https://img.shields.io/pypi/v/ec2-metadata.svg
         :target: https://pypi.python.org/pypi/ec2-metadata
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 An easy interface to query the EC2 metadata API, with caching.
 
 A quick example:

--- a/ec2_metadata.py
+++ b/ec2_metadata.py
@@ -1,23 +1,22 @@
 import requests
 from cached_property import cached_property
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '2.0.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "2.0.0"
 
-__all__ = ('ec2_metadata',)
+__all__ = ("ec2_metadata",)
 
 
 # We purposefully use a fixed version of the service rather than 'latest' in
 # case any backward incompatible changes are made in the future
-SERVICE_URL = 'http://169.254.169.254/2016-09-02/'
-DYNAMIC_URL = SERVICE_URL + 'dynamic/'
-METADATA_URL = SERVICE_URL + 'meta-data/'
-USERDATA_URL = SERVICE_URL + 'user-data/'
+SERVICE_URL = "http://169.254.169.254/2016-09-02/"
+DYNAMIC_URL = SERVICE_URL + "dynamic/"
+METADATA_URL = SERVICE_URL + "meta-data/"
+USERDATA_URL = SERVICE_URL + "user-data/"
 
 
 class BaseLazyObject(object):
-
     def clear_all(self):
         for key in tuple(self.__dict__.keys()):
             if isinstance(getattr(self.__class__, key, None), cached_property):
@@ -25,7 +24,6 @@ class BaseLazyObject(object):
 
 
 class EC2Metadata(BaseLazyObject):
-
     def __init__(self, session=None):
         if session is None:
             session = requests.Session()
@@ -39,111 +37,111 @@ class EC2Metadata(BaseLazyObject):
 
     @property
     def account_id(self):
-        return self.instance_identity_document['accountId']
+        return self.instance_identity_document["accountId"]
 
     @cached_property
     def ami_id(self):
-        return self._get_url(METADATA_URL + 'ami-id').text
+        return self._get_url(METADATA_URL + "ami-id").text
 
     @cached_property
     def availability_zone(self):
-        return self._get_url(METADATA_URL + 'placement/availability-zone').text
+        return self._get_url(METADATA_URL + "placement/availability-zone").text
 
     @cached_property
     def ami_launch_index(self):
-        return int(self._get_url(METADATA_URL + 'ami-launch-index').text)
+        return int(self._get_url(METADATA_URL + "ami-launch-index").text)
 
     @cached_property
     def ami_manifest_path(self):
-        return self._get_url(METADATA_URL + 'ami-manifest-path').text
+        return self._get_url(METADATA_URL + "ami-manifest-path").text
 
     @cached_property
     def iam_info(self):
-        resp = self._get_url(METADATA_URL + 'iam/info', allow_404=True)
+        resp = self._get_url(METADATA_URL + "iam/info", allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.json()
 
     @property
     def instance_action(self):
-        return self._get_url(METADATA_URL + 'instance-action').text
+        return self._get_url(METADATA_URL + "instance-action").text
 
     @cached_property
     def instance_id(self):
-        return self._get_url(METADATA_URL + 'instance-id').text
+        return self._get_url(METADATA_URL + "instance-id").text
 
     @cached_property
     def instance_identity_document(self):
-        return self._get_url(DYNAMIC_URL + 'instance-identity/document').json()
+        return self._get_url(DYNAMIC_URL + "instance-identity/document").json()
 
     @property
     def instance_profile_arn(self):
         iam_info = self.iam_info
         if iam_info is None:
             return None
-        return iam_info['InstanceProfileArn']
+        return iam_info["InstanceProfileArn"]
 
     @property
     def instance_profile_id(self):
         iam_info = self.iam_info
         if iam_info is None:
             return None
-        return iam_info['InstanceProfileId']
+        return iam_info["InstanceProfileId"]
 
     @cached_property
     def instance_type(self):
-        return self._get_url(METADATA_URL + 'instance-type').text
+        return self._get_url(METADATA_URL + "instance-type").text
 
     @cached_property
     def kernel_id(self):
-        resp = self._get_url(METADATA_URL + 'kernel-id', allow_404=True)
+        resp = self._get_url(METADATA_URL + "kernel-id", allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def mac(self):
-        return self._get_url(METADATA_URL + 'mac').text
+        return self._get_url(METADATA_URL + "mac").text
 
     @cached_property
     def network_interfaces(self):
-        macs_text = self._get_url(METADATA_URL + 'network/interfaces/macs/').text
-        macs = [line.rstrip('/') for line in macs_text.splitlines()]
+        macs_text = self._get_url(METADATA_URL + "network/interfaces/macs/").text
+        macs = [line.rstrip("/") for line in macs_text.splitlines()]
         return {mac: NetworkInterface(mac, self) for mac in macs}
 
     @cached_property
     def private_hostname(self):
-        return self._get_url(METADATA_URL + 'local-hostname').text
+        return self._get_url(METADATA_URL + "local-hostname").text
 
     @cached_property
     def private_ipv4(self):
-        return self._get_url(METADATA_URL + 'local-ipv4').text
+        return self._get_url(METADATA_URL + "local-ipv4").text
 
     @cached_property
     def public_hostname(self):
-        resp = self._get_url(METADATA_URL + 'public-hostname', allow_404=True)
+        resp = self._get_url(METADATA_URL + "public-hostname", allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def public_ipv4(self):
-        resp = self._get_url(METADATA_URL + 'public-ipv4', allow_404=True)
+        resp = self._get_url(METADATA_URL + "public-ipv4", allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def region(self):
-        return self.instance_identity_document['region']
+        return self.instance_identity_document["region"]
 
     @cached_property
     def reservation_id(self):
-        return self._get_url(METADATA_URL + 'reservation-id').text
+        return self._get_url(METADATA_URL + "reservation-id").text
 
     @cached_property
     def security_groups(self):
-        return self._get_url(METADATA_URL + 'security-groups').text.splitlines()
+        return self._get_url(METADATA_URL + "security-groups").text.splitlines()
 
     @cached_property
     def user_data(self):
@@ -154,7 +152,6 @@ class EC2Metadata(BaseLazyObject):
 
 
 class NetworkInterface(BaseLazyObject):
-
     def __init__(self, mac, parent=None):
         self.mac = mac
         if parent is None:
@@ -163,35 +160,33 @@ class NetworkInterface(BaseLazyObject):
             self.parent = parent
 
     def __repr__(self):
-        return 'NetworkInterface({mac})'.format(mac=repr(self.mac))
+        return "NetworkInterface({mac})".format(mac=repr(self.mac))
 
     def __eq__(self, other):
         return (
-            isinstance(other, NetworkInterface) and
-            self.mac == other.mac and
-            self.parent == other.parent
+            isinstance(other, NetworkInterface)
+            and self.mac == other.mac
+            and self.parent == other.parent
         )
 
     def _url(self, item):
-        return '{base}network/interfaces/macs/{mac}/{item}'.format(
-            base=METADATA_URL,
-            mac=self.mac,
-            item=item,
+        return "{base}network/interfaces/macs/{mac}/{item}".format(
+            base=METADATA_URL, mac=self.mac, item=item
         )
 
     @cached_property
     def device_number(self):
-        return int(self.parent._get_url(self._url('device-number')).text)
+        return int(self.parent._get_url(self._url("device-number")).text)
 
     @cached_property
     def interface_id(self):
-        return self.parent._get_url(self._url('interface-id')).text
+        return self.parent._get_url(self._url("interface-id")).text
 
     @cached_property
     def ipv4_associations(self):
         associations = {}
         for public_ip in self.public_ipv4s:
-            url = self._url('ipv4-associations/{}'.format(public_ip))
+            url = self._url("ipv4-associations/{}".format(public_ip))
             resp = self.parent._get_url(url)
             private_ips = resp.text.splitlines()
             associations[public_ip] = private_ips
@@ -199,84 +194,86 @@ class NetworkInterface(BaseLazyObject):
 
     @cached_property
     def ipv6s(self):
-        resp = self.parent._get_url(self._url('ipv6s'), allow_404=True)
+        resp = self.parent._get_url(self._url("ipv6s"), allow_404=True)
         if resp.status_code == 404:
             return []
         return resp.text.splitlines()
 
     @cached_property
     def owner_id(self):
-        return self.parent._get_url(self._url('owner-id')).text
+        return self.parent._get_url(self._url("owner-id")).text
 
     @cached_property
     def private_hostname(self):
-        return self.parent._get_url(self._url('local-hostname')).text
+        return self.parent._get_url(self._url("local-hostname")).text
 
     @cached_property
     def private_ipv4s(self):
-        return self.parent._get_url(self._url('local-ipv4s')).text.splitlines()
+        return self.parent._get_url(self._url("local-ipv4s")).text.splitlines()
 
     @cached_property
     def public_hostname(self):
-        resp = self.parent._get_url(self._url('public-hostname'), allow_404=True)
+        resp = self.parent._get_url(self._url("public-hostname"), allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def public_ipv4s(self):
-        resp = self.parent._get_url(self._url('public-ipv4s'), allow_404=True)
+        resp = self.parent._get_url(self._url("public-ipv4s"), allow_404=True)
         if resp.status_code == 404:
             return []
         return resp.text.splitlines()
 
     @cached_property
     def security_groups(self):
-        return self.parent._get_url(self._url('security-groups')).text.splitlines()
+        return self.parent._get_url(self._url("security-groups")).text.splitlines()
 
     @cached_property
     def security_group_ids(self):
-        return self.parent._get_url(self._url('security-group-ids')).text.splitlines()
+        return self.parent._get_url(self._url("security-group-ids")).text.splitlines()
 
     @cached_property
     def subnet_id(self):
-        return self.parent._get_url(self._url('subnet-id')).text
+        return self.parent._get_url(self._url("subnet-id")).text
 
     @cached_property
     def subnet_ipv4_cidr_block(self):
-        resp = self.parent._get_url(self._url('subnet-ipv4-cidr-block'), allow_404=True)
+        resp = self.parent._get_url(self._url("subnet-ipv4-cidr-block"), allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def subnet_ipv6_cidr_blocks(self):
-        resp = self.parent._get_url(self._url('subnet-ipv6-cidr-blocks'), allow_404=True)
+        resp = self.parent._get_url(
+            self._url("subnet-ipv6-cidr-blocks"), allow_404=True
+        )
         if resp.status_code == 404:
             return []
         return resp.text.splitlines()
 
     @cached_property
     def vpc_id(self):
-        return self.parent._get_url(self._url('vpc-id')).text
+        return self.parent._get_url(self._url("vpc-id")).text
 
     @cached_property
     def vpc_ipv4_cidr_block(self):
-        resp = self.parent._get_url(self._url('vpc-ipv4-cidr-block'), allow_404=True)
+        resp = self.parent._get_url(self._url("vpc-ipv4-cidr-block"), allow_404=True)
         if resp.status_code == 404:
             return None
         return resp.text
 
     @cached_property
     def vpc_ipv4_cidr_blocks(self):
-        resp = self.parent._get_url(self._url('vpc-ipv4-cidr-blocks'), allow_404=True)
+        resp = self.parent._get_url(self._url("vpc-ipv4-cidr-blocks"), allow_404=True)
         if resp.status_code == 404:
             return []
         return resp.text.splitlines()
 
     @cached_property
     def vpc_ipv6_cidr_blocks(self):
-        resp = self.parent._get_url(self._url('vpc-ipv6-cidr-blocks'), allow_404=True)
+        resp = self.parent._get_url(self._url("vpc-ipv6-cidr-blocks"), allow_404=True)
         if resp.status_code == 404:
             return []
         return resp.text.splitlines()

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,9 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -68,9 +68,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -27,6 +34,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -68,9 +79,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -151,6 +162,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer, requests-mock
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,8 @@
+black ; python_version == '3.7.*'
 cached-property
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 isort
 multilint
 pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,21 @@
 [flake8]
-max_line_length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 
 [isort]
 include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = ec2_metadata
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE
 
 [tool:multilint]
 paths = ec2_metadata.py
+        setup.py
         test_ec2_metadata.py

--- a/setup.py
+++ b/setup.py
@@ -4,49 +4,46 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('ec2_metadata.py')
+version = get_version("ec2_metadata.py")
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='ec2-metadata',
+    name="ec2-metadata",
     version=version,
-    description='An easy interface to query the EC2 metadata API, with caching.',
-    long_description=readme + '\n\n' + history,
-    author='Adam Johnson',
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/ec2-metadata',
-    py_modules=['ec2_metadata'],
+    description="An easy interface to query the EC2 metadata API, with caching.",
+    long_description=readme + "\n\n" + history,
+    author="Adam Johnson",
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/ec2-metadata",
+    py_modules=["ec2_metadata"],
     include_package_data=True,
-    install_requires=[
-        'cached-property',
-        'requests',
-    ],
-    python_requires='>=3.5',
-    license='ISC License',
+    install_requires=["cached-property", "requests"],
+    python_requires=">=3.5",
+    license="ISC License",
     zip_safe=False,
-    keywords='AWS, EC2, metadata',
+    keywords="AWS, EC2, metadata",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_ec2_metadata.py
+++ b/test_ec2_metadata.py
@@ -1,7 +1,13 @@
 import pytest
 import requests
 
-from ec2_metadata import DYNAMIC_URL, METADATA_URL, USERDATA_URL, NetworkInterface, ec2_metadata
+from ec2_metadata import (
+    DYNAMIC_URL,
+    METADATA_URL,
+    USERDATA_URL,
+    NetworkInterface,
+    ec2_metadata,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -9,102 +15,103 @@ def clear_it():
     ec2_metadata.clear_all()
 
 
-example_mac = '00:11:22:33:44:55'
+example_mac = "00:11:22:33:44:55"
 
 
 # EC2Metadata tests
 
+
 def add_identity_doc_response(requests_mock, overrides=None):
     identity_doc = {
-        'accountId': '123456789012',
-        'architecture': 'x86_64',
-        'availabilityZone': 'eu-west-1a',
-        'imageId': 'ami-12345678',
-        'instanceId': 'i-12345678',
-        'instanceType': 't2.nano',
-        'privateIp': '172.30.0.0',
-        'region': 'eu-west-1',
-        'version': '2010-08-31',
+        "accountId": "123456789012",
+        "architecture": "x86_64",
+        "availabilityZone": "eu-west-1a",
+        "imageId": "ami-12345678",
+        "instanceId": "i-12345678",
+        "instanceType": "t2.nano",
+        "privateIp": "172.30.0.0",
+        "region": "eu-west-1",
+        "version": "2010-08-31",
     }
     if overrides:
         identity_doc.update(overrides)
-    requests_mock.get(DYNAMIC_URL + 'instance-identity/document', json=identity_doc)
+    requests_mock.get(DYNAMIC_URL + "instance-identity/document", json=identity_doc)
     return identity_doc
 
 
 def test_account_id(requests_mock):
-    add_identity_doc_response(requests_mock, {'accountId': '1234'})
-    assert ec2_metadata.account_id == '1234'
+    add_identity_doc_response(requests_mock, {"accountId": "1234"})
+    assert ec2_metadata.account_id == "1234"
 
 
 def test_account_id_error(requests_mock):
-    requests_mock.get(DYNAMIC_URL + 'instance-identity/document', status_code=500)
+    requests_mock.get(DYNAMIC_URL + "instance-identity/document", status_code=500)
     with pytest.raises(requests.exceptions.HTTPError):
         ec2_metadata.account_id
 
 
 def test_ami_id(requests_mock):
-    requests_mock.get(METADATA_URL + 'ami-id', text='ami-12345678')
-    assert ec2_metadata.ami_id == 'ami-12345678'
+    requests_mock.get(METADATA_URL + "ami-id", text="ami-12345678")
+    assert ec2_metadata.ami_id == "ami-12345678"
 
 
 def test_ami_id_cached(requests_mock):
-    requests_mock.get(METADATA_URL + 'ami-id', text='ami-12345678')
+    requests_mock.get(METADATA_URL + "ami-id", text="ami-12345678")
     ec2_metadata.ami_id
-    requests_mock.get(METADATA_URL + 'ami-id', status_code=500)
+    requests_mock.get(METADATA_URL + "ami-id", status_code=500)
     ec2_metadata.ami_id  # no error
 
 
 def test_ami_id_cached_cleared(requests_mock):
-    requests_mock.get(METADATA_URL + 'ami-id', text='ami-12345678')
+    requests_mock.get(METADATA_URL + "ami-id", text="ami-12345678")
     ec2_metadata.ami_id
 
     ec2_metadata.clear_all()
-    requests_mock.get(METADATA_URL + 'ami-id', status_code=500)
+    requests_mock.get(METADATA_URL + "ami-id", status_code=500)
 
     with pytest.raises(requests.exceptions.HTTPError):
         ec2_metadata.ami_id
 
 
 def test_ami_launch_index(requests_mock):
-    requests_mock.get(METADATA_URL + 'ami-launch-index', text='0')
+    requests_mock.get(METADATA_URL + "ami-launch-index", text="0")
     assert ec2_metadata.ami_launch_index == 0
 
 
 def test_ami_manifest_path(requests_mock):
-    requests_mock.get(METADATA_URL + 'ami-manifest-path', text='(unknown)')
-    assert ec2_metadata.ami_manifest_path == '(unknown)'
+    requests_mock.get(METADATA_URL + "ami-manifest-path", text="(unknown)")
+    assert ec2_metadata.ami_manifest_path == "(unknown)"
 
 
 def test_availability_zone(requests_mock):
-    requests_mock.get(METADATA_URL + 'placement/availability-zone', text='eu-west-1a')
-    assert ec2_metadata.availability_zone == 'eu-west-1a'
+    requests_mock.get(METADATA_URL + "placement/availability-zone", text="eu-west-1a")
+    assert ec2_metadata.availability_zone == "eu-west-1a"
 
 
 def test_iam_info(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', text='{}')
+    requests_mock.get(METADATA_URL + "iam/info", text="{}")
     assert ec2_metadata.iam_info == {}
 
 
 def test_iam_info_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', status_code=404)
+    requests_mock.get(METADATA_URL + "iam/info", status_code=404)
     assert ec2_metadata.iam_info is None
 
 
 def test_iam_info_unexpected(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', status_code=500)
+    requests_mock.get(METADATA_URL + "iam/info", status_code=500)
     with pytest.raises(requests.exceptions.HTTPError):
         ec2_metadata.iam_info
 
 
 def test_instance_action(requests_mock):
-    requests_mock.get(METADATA_URL + 'instance-action', text='none')
-    assert ec2_metadata.instance_action == 'none'
+    requests_mock.get(METADATA_URL + "instance-action", text="none")
+    assert ec2_metadata.instance_action == "none"
 
 
 def test_instance_id(requests_mock):
-    requests_mock.get(METADATA_URL + 'instance-id', text='i-12345678')
-    assert ec2_metadata.instance_id == 'i-12345678'
+    requests_mock.get(METADATA_URL + "instance-id", text="i-12345678")
+    assert ec2_metadata.instance_id == "i-12345678"
 
 
 def test_instance_identity(requests_mock):
@@ -113,106 +120,118 @@ def test_instance_identity(requests_mock):
 
 
 def test_instance_profile_arn(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', text='{"InstanceProfileArn": "arn:foobar"}')
-    assert ec2_metadata.instance_profile_arn == 'arn:foobar'
+    requests_mock.get(
+        METADATA_URL + "iam/info", text='{"InstanceProfileArn": "arn:foobar"}'
+    )
+    assert ec2_metadata.instance_profile_arn == "arn:foobar"
 
 
 def test_instance_profile_arn_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', status_code=404)
+    requests_mock.get(METADATA_URL + "iam/info", status_code=404)
     assert ec2_metadata.instance_profile_arn is None
 
 
 def test_instance_profile_id(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', text='{"InstanceProfileId": "some-id"}')
-    assert ec2_metadata.instance_profile_id == 'some-id'
+    requests_mock.get(
+        METADATA_URL + "iam/info", text='{"InstanceProfileId": "some-id"}'
+    )
+    assert ec2_metadata.instance_profile_id == "some-id"
 
 
 def test_instance_profile_id_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'iam/info', status_code=404)
+    requests_mock.get(METADATA_URL + "iam/info", status_code=404)
     assert ec2_metadata.instance_profile_id is None
 
 
 def test_instance_type(requests_mock):
-    requests_mock.get(METADATA_URL + 'instance-type', text='t2.nano')
-    assert ec2_metadata.instance_type == 't2.nano'
+    requests_mock.get(METADATA_URL + "instance-type", text="t2.nano")
+    assert ec2_metadata.instance_type == "t2.nano"
 
 
 def test_kernel_id(requests_mock):
-    requests_mock.get(METADATA_URL + 'kernel-id', text='aki-dc9ed9af')
-    assert ec2_metadata.kernel_id == 'aki-dc9ed9af'
+    requests_mock.get(METADATA_URL + "kernel-id", text="aki-dc9ed9af")
+    assert ec2_metadata.kernel_id == "aki-dc9ed9af"
 
 
 def test_kernel_id_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'kernel-id', status_code=404)
+    requests_mock.get(METADATA_URL + "kernel-id", status_code=404)
     assert ec2_metadata.kernel_id is None
 
 
 def test_mac(requests_mock):
-    requests_mock.get(METADATA_URL + 'mac', text=example_mac)
+    requests_mock.get(METADATA_URL + "mac", text=example_mac)
     assert ec2_metadata.mac == example_mac
 
 
 def test_network_interfaces(requests_mock):
-    requests_mock.get(METADATA_URL + 'network/interfaces/macs/', text=example_mac + '/')
-    assert ec2_metadata.network_interfaces == {example_mac: NetworkInterface(example_mac, ec2_metadata)}
+    requests_mock.get(METADATA_URL + "network/interfaces/macs/", text=example_mac + "/")
+    assert ec2_metadata.network_interfaces == {
+        example_mac: NetworkInterface(example_mac, ec2_metadata)
+    }
 
 
 def test_private_hostname(requests_mock):
-    requests_mock.get(METADATA_URL + 'local-hostname', text='ip-172-30-0-0.eu-west-1.compute.internal')
-    assert ec2_metadata.private_hostname == 'ip-172-30-0-0.eu-west-1.compute.internal'
+    requests_mock.get(
+        METADATA_URL + "local-hostname", text="ip-172-30-0-0.eu-west-1.compute.internal"
+    )
+    assert ec2_metadata.private_hostname == "ip-172-30-0-0.eu-west-1.compute.internal"
 
 
 def test_private_ipv4(requests_mock):
-    requests_mock.get(METADATA_URL + 'local-ipv4', text='172.30.0.0')
-    assert ec2_metadata.private_ipv4 == '172.30.0.0'
+    requests_mock.get(METADATA_URL + "local-ipv4", text="172.30.0.0")
+    assert ec2_metadata.private_ipv4 == "172.30.0.0"
 
 
 def test_public_hostname(requests_mock):
-    requests_mock.get(METADATA_URL + 'public-hostname', text='ec2-1-2-3-4.compute-1.amazonaws.com')
-    assert ec2_metadata.public_hostname == 'ec2-1-2-3-4.compute-1.amazonaws.com'
+    requests_mock.get(
+        METADATA_URL + "public-hostname", text="ec2-1-2-3-4.compute-1.amazonaws.com"
+    )
+    assert ec2_metadata.public_hostname == "ec2-1-2-3-4.compute-1.amazonaws.com"
 
 
 def test_public_hostname_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'public-hostname', status_code=404)
+    requests_mock.get(METADATA_URL + "public-hostname", status_code=404)
     assert ec2_metadata.public_hostname is None
 
 
 def test_public_ipv4(requests_mock):
-    requests_mock.get(METADATA_URL + 'public-ipv4', text='1.2.3.4')
-    assert ec2_metadata.public_ipv4 == '1.2.3.4'
+    requests_mock.get(METADATA_URL + "public-ipv4", text="1.2.3.4")
+    assert ec2_metadata.public_ipv4 == "1.2.3.4"
 
 
 def test_public_ipv4_none(requests_mock):
-    requests_mock.get(METADATA_URL + 'public-ipv4', status_code=404)
+    requests_mock.get(METADATA_URL + "public-ipv4", status_code=404)
     assert ec2_metadata.public_ipv4 is None
 
 
 def test_region(requests_mock):
-    add_identity_doc_response(requests_mock, {'region': 'eu-whatever-1'})
-    assert ec2_metadata.region == 'eu-whatever-1'
+    add_identity_doc_response(requests_mock, {"region": "eu-whatever-1"})
+    assert ec2_metadata.region == "eu-whatever-1"
 
 
 def test_reservation_id(requests_mock):
-    requests_mock.get(METADATA_URL + 'reservation-id', text='r-12345678901234567')
-    assert ec2_metadata.reservation_id == 'r-12345678901234567'
+    requests_mock.get(METADATA_URL + "reservation-id", text="r-12345678901234567")
+    assert ec2_metadata.reservation_id == "r-12345678901234567"
 
 
 def test_security_groups_single(requests_mock):
     # most common case: a single SG
-    requests_mock.get(METADATA_URL + 'security-groups', text='security-group-one')
-    assert ec2_metadata.security_groups == ['security-group-one']
+    requests_mock.get(METADATA_URL + "security-groups", text="security-group-one")
+    assert ec2_metadata.security_groups == ["security-group-one"]
 
 
 def test_security_groups_two(requests_mock):
     # another common case: multiple SGs
-    requests_mock.get(METADATA_URL + 'security-groups', text="security-group-one\nsecurity-group-2")
-    assert ec2_metadata.security_groups == ['security-group-one', 'security-group-2']
+    requests_mock.get(
+        METADATA_URL + "security-groups", text="security-group-one\nsecurity-group-2"
+    )
+    assert ec2_metadata.security_groups == ["security-group-one", "security-group-2"]
 
 
 def test_security_groups_emptystring(requests_mock):
-    # check '' too. Can't create an instance without a SG but we should safely handle it,
-    # perhaps it's possible in OpenStack.
-    requests_mock.get(METADATA_URL + 'security-groups', text='')
+    # Check '' too. Can't create an instance without a SG on EC2 but we should
+    # safely handle it, perhaps it's possible in e.g. OpenStack.
+    requests_mock.get(METADATA_URL + "security-groups", text="")
     assert ec2_metadata.security_groups == []
 
 
@@ -222,163 +241,189 @@ def test_user_data_none(requests_mock):
 
 
 def test_user_data_something(requests_mock):
-    requests_mock.get(USERDATA_URL, content=b'foobar')
-    assert ec2_metadata.user_data == b'foobar'
+    requests_mock.get(USERDATA_URL, content=b"foobar")
+    assert ec2_metadata.user_data == b"foobar"
 
 
 # NetworkInterface tests
 
-def add_interface_response(requests_mock, url, text='', **kwargs):
-    full_url = METADATA_URL + 'network/interfaces/macs/' + example_mac + url
+
+def add_interface_response(requests_mock, url, text="", **kwargs):
+    full_url = METADATA_URL + "network/interfaces/macs/" + example_mac + url
     requests_mock.get(full_url, text=text, **kwargs)
 
 
 def test_network_interface_equal():
-    assert NetworkInterface('a') == NetworkInterface('a')
+    assert NetworkInterface("a") == NetworkInterface("a")
 
 
 def test_network_interface_not_equal():
-    assert NetworkInterface('a') != NetworkInterface('b')
+    assert NetworkInterface("a") != NetworkInterface("b")
 
 
 def test_network_interface_not_equal_class():
-    assert NetworkInterface('a') != 'a'
+    assert NetworkInterface("a") != "a"
 
 
 def test_network_interface_repr():
-    assert "'abc'" in repr(NetworkInterface('abc'))
+    assert "'abc'" in repr(NetworkInterface("abc"))
 
 
 def test_network_interface_device_number(requests_mock):
-    add_interface_response(requests_mock, '/device-number', '0')
+    add_interface_response(requests_mock, "/device-number", "0")
     assert NetworkInterface(example_mac).device_number == 0
 
 
 def test_network_interface_interface_id(requests_mock):
-    add_interface_response(requests_mock, '/interface-id', 'eni-12345')
-    assert NetworkInterface(example_mac).interface_id == 'eni-12345'
+    add_interface_response(requests_mock, "/interface-id", "eni-12345")
+    assert NetworkInterface(example_mac).interface_id == "eni-12345"
 
 
 def test_network_interface_ipv4_associations(requests_mock):
-    add_interface_response(requests_mock, '/public-ipv4s', '54.0.0.0\n54.0.0.1')
-    add_interface_response(requests_mock, '/ipv4-associations/54.0.0.0', '172.30.0.0')
-    add_interface_response(requests_mock, '/ipv4-associations/54.0.0.1', '172.30.0.1')
+    add_interface_response(requests_mock, "/public-ipv4s", "54.0.0.0\n54.0.0.1")
+    add_interface_response(requests_mock, "/ipv4-associations/54.0.0.0", "172.30.0.0")
+    add_interface_response(requests_mock, "/ipv4-associations/54.0.0.1", "172.30.0.1")
     assert NetworkInterface(example_mac).ipv4_associations == {
-        '54.0.0.0': ['172.30.0.0'],
-        '54.0.0.1': ['172.30.0.1'],
+        "54.0.0.0": ["172.30.0.0"],
+        "54.0.0.1": ["172.30.0.1"],
     }
 
 
 def test_network_interface_ipv6s(requests_mock):
-    add_interface_response(requests_mock, '/ipv6s', '2001:db8:abcd:ef00:cbe5:798:aa26:169b\n2001:db8:abcd:ef00::f')
-    assert NetworkInterface(example_mac).ipv6s == ['2001:db8:abcd:ef00:cbe5:798:aa26:169b', '2001:db8:abcd:ef00::f']
+    add_interface_response(
+        requests_mock,
+        "/ipv6s",
+        "2001:db8:abcd:ef00:cbe5:798:aa26:169b\n2001:db8:abcd:ef00::f",
+    )
+    assert NetworkInterface(example_mac).ipv6s == [
+        "2001:db8:abcd:ef00:cbe5:798:aa26:169b",
+        "2001:db8:abcd:ef00::f",
+    ]
 
 
 def test_network_interface_ipv6s_none(requests_mock):
-    add_interface_response(requests_mock, '/ipv6s', status_code=404)
+    add_interface_response(requests_mock, "/ipv6s", status_code=404)
     assert NetworkInterface(example_mac).ipv6s == []
 
 
 def test_network_interface_owner_id(requests_mock):
-    add_interface_response(requests_mock, '/owner-id', '123456789012')
-    assert NetworkInterface(example_mac).owner_id == '123456789012'
+    add_interface_response(requests_mock, "/owner-id", "123456789012")
+    assert NetworkInterface(example_mac).owner_id == "123456789012"
 
 
 def test_network_interface_private_hostname(requests_mock):
-    add_interface_response(requests_mock, '/local-hostname', 'ip-172-30-0-0.eu-west-1.compute.internal')
-    assert NetworkInterface(example_mac).private_hostname == 'ip-172-30-0-0.eu-west-1.compute.internal'
+    add_interface_response(
+        requests_mock, "/local-hostname", "ip-172-30-0-0.eu-west-1.compute.internal"
+    )
+    assert (
+        NetworkInterface(example_mac).private_hostname
+        == "ip-172-30-0-0.eu-west-1.compute.internal"
+    )
 
 
 def test_network_interface_private_ipv4s(requests_mock):
-    add_interface_response(requests_mock, '/local-ipv4s', '172.30.0.0\n172.30.0.1')
-    assert NetworkInterface(example_mac).private_ipv4s == ['172.30.0.0', '172.30.0.1']
+    add_interface_response(requests_mock, "/local-ipv4s", "172.30.0.0\n172.30.0.1")
+    assert NetworkInterface(example_mac).private_ipv4s == ["172.30.0.0", "172.30.0.1"]
 
 
 def test_network_interface_public_hostname(requests_mock):
-    add_interface_response(requests_mock, '/public-hostname', '')
-    assert NetworkInterface(example_mac).public_hostname == ''
+    add_interface_response(requests_mock, "/public-hostname", "")
+    assert NetworkInterface(example_mac).public_hostname == ""
 
 
 def test_network_interface_public_hostname_none(requests_mock):
-    add_interface_response(requests_mock, '/public-hostname', status_code=404)
+    add_interface_response(requests_mock, "/public-hostname", status_code=404)
     assert NetworkInterface(example_mac).public_hostname is None
 
 
 def test_network_interface_public_ipv4s(requests_mock):
-    add_interface_response(requests_mock, '/public-ipv4s', '54.0.0.0\n54.0.0.1')
-    assert NetworkInterface(example_mac).public_ipv4s == ['54.0.0.0', '54.0.0.1']
+    add_interface_response(requests_mock, "/public-ipv4s", "54.0.0.0\n54.0.0.1")
+    assert NetworkInterface(example_mac).public_ipv4s == ["54.0.0.0", "54.0.0.1"]
 
 
 def test_network_interface_public_ipv4s_empty(requests_mock):
-    add_interface_response(requests_mock, '/public-ipv4s', status_code=404)
+    add_interface_response(requests_mock, "/public-ipv4s", status_code=404)
     assert NetworkInterface(example_mac).public_ipv4s == []
 
 
 def test_network_interface_security_groups(requests_mock):
-    add_interface_response(requests_mock, '/security-groups', 'foo\nbar')
-    assert NetworkInterface(example_mac).security_groups == ['foo', 'bar']
+    add_interface_response(requests_mock, "/security-groups", "foo\nbar")
+    assert NetworkInterface(example_mac).security_groups == ["foo", "bar"]
 
 
 def test_network_interface_security_group_ids(requests_mock):
-    add_interface_response(requests_mock, '/security-group-ids', 'sg-12345678\nsg-12345679')
-    assert NetworkInterface(example_mac).security_group_ids == ['sg-12345678', 'sg-12345679']
+    add_interface_response(
+        requests_mock, "/security-group-ids", "sg-12345678\nsg-12345679"
+    )
+    assert NetworkInterface(example_mac).security_group_ids == [
+        "sg-12345678",
+        "sg-12345679",
+    ]
 
 
 def test_network_interface_subnet_id(requests_mock):
-    add_interface_response(requests_mock, '/subnet-id', 'subnet-12345678')
-    assert NetworkInterface(example_mac).subnet_id == 'subnet-12345678'
+    add_interface_response(requests_mock, "/subnet-id", "subnet-12345678")
+    assert NetworkInterface(example_mac).subnet_id == "subnet-12345678"
 
 
 def test_network_interface_subnet_ipv4_cidr_block(requests_mock):
-    add_interface_response(requests_mock, '/subnet-ipv4-cidr-block', '172.30.0.0/24')
-    assert NetworkInterface(example_mac).subnet_ipv4_cidr_block == '172.30.0.0/24'
+    add_interface_response(requests_mock, "/subnet-ipv4-cidr-block", "172.30.0.0/24")
+    assert NetworkInterface(example_mac).subnet_ipv4_cidr_block == "172.30.0.0/24"
 
 
 def test_network_interface_subnet_ipv4_cidr_block_none(requests_mock):
-    add_interface_response(requests_mock, '/subnet-ipv4-cidr-block', status_code=404)
+    add_interface_response(requests_mock, "/subnet-ipv4-cidr-block", status_code=404)
     assert NetworkInterface(example_mac).subnet_ipv4_cidr_block is None
 
 
 def test_network_interface_subnet_ipv6_cidr_blocks(requests_mock):
-    add_interface_response(requests_mock, '/subnet-ipv6-cidr-blocks', '2001:db8:abcd:ef00::/64')
-    assert NetworkInterface(example_mac).subnet_ipv6_cidr_blocks == ['2001:db8:abcd:ef00::/64']
+    add_interface_response(
+        requests_mock, "/subnet-ipv6-cidr-blocks", "2001:db8:abcd:ef00::/64"
+    )
+    assert NetworkInterface(example_mac).subnet_ipv6_cidr_blocks == [
+        "2001:db8:abcd:ef00::/64"
+    ]
 
 
 def test_network_interface_subnet_ipv6_cidr_blocks_none(requests_mock):
-    add_interface_response(requests_mock, '/subnet-ipv6-cidr-blocks', status_code=404)
+    add_interface_response(requests_mock, "/subnet-ipv6-cidr-blocks", status_code=404)
     assert NetworkInterface(example_mac).subnet_ipv6_cidr_blocks == []
 
 
 def test_network_interface_vpc_id(requests_mock):
-    add_interface_response(requests_mock, '/vpc-id', 'vpc-12345678')
-    assert NetworkInterface(example_mac).vpc_id == 'vpc-12345678'
+    add_interface_response(requests_mock, "/vpc-id", "vpc-12345678")
+    assert NetworkInterface(example_mac).vpc_id == "vpc-12345678"
 
 
 def test_network_interface_vpc_ipv4_cidr_block(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv4-cidr-block', '172.30.0.0/16')
-    assert NetworkInterface(example_mac).vpc_ipv4_cidr_block == '172.30.0.0/16'
+    add_interface_response(requests_mock, "/vpc-ipv4-cidr-block", "172.30.0.0/16")
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_block == "172.30.0.0/16"
 
 
 def test_network_interface_vpc_ipv4_cidr_block_none(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv4-cidr-block', status_code=404)
+    add_interface_response(requests_mock, "/vpc-ipv4-cidr-block", status_code=404)
     assert NetworkInterface(example_mac).vpc_ipv4_cidr_block is None
 
 
 def test_network_interface_vpc_ipv4_cidr_blocks(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv4-cidr-blocks', '172.30.0.0/16')
-    assert NetworkInterface(example_mac).vpc_ipv4_cidr_blocks == ['172.30.0.0/16']
+    add_interface_response(requests_mock, "/vpc-ipv4-cidr-blocks", "172.30.0.0/16")
+    assert NetworkInterface(example_mac).vpc_ipv4_cidr_blocks == ["172.30.0.0/16"]
 
 
 def test_network_interface_vpc_ipv4_cidr_blocks_none(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv4-cidr-blocks', status_code=404)
+    add_interface_response(requests_mock, "/vpc-ipv4-cidr-blocks", status_code=404)
     assert NetworkInterface(example_mac).vpc_ipv4_cidr_blocks == []
 
 
 def test_network_interface_vpc_ipv6_cidr_blocks(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv6-cidr-blocks', '2001:db8:abcd:ef00::/56')
-    assert NetworkInterface(example_mac).vpc_ipv6_cidr_blocks == ['2001:db8:abcd:ef00::/56']
+    add_interface_response(
+        requests_mock, "/vpc-ipv6-cidr-blocks", "2001:db8:abcd:ef00::/56"
+    )
+    assert NetworkInterface(example_mac).vpc_ipv6_cidr_blocks == [
+        "2001:db8:abcd:ef00::/56"
+    ]
 
 
 def test_network_interface_vpc_ipv6_cidr_blocks_none(requests_mock):
-    add_interface_response(requests_mock, '/vpc-ipv6-cidr-blocks', status_code=404)
+    add_interface_response(requests_mock, "/vpc-ipv6-cidr-blocks", status_code=404)
     assert NetworkInterface(example_mac).vpc_ipv6_cidr_blocks == []


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge