### PR TITLE
Add spot instance-action functionality to EC2Metadata object

### DIFF
--- a/src/ec2_metadata.py
+++ b/src/ec2_metadata.py
@@ -170,7 +170,11 @@ class EC2Metadata(BaseLazyObject):
 
     @property
     def spot_instance_action(self):
-        return self._get_url(METADATA_URL + "spot/instance-action").text
+        resp = self._get_url(METADATA_URL + "spot/instance-action", allow_404=True)
+        if resp.status_code == 404:
+            return None
+        return resp.text
+
 
     @cached_property
     def user_data(self):

--- a/src/ec2_metadata.py
+++ b/src/ec2_metadata.py
@@ -168,6 +168,10 @@ class EC2Metadata(BaseLazyObject):
     def security_groups(self):
         return self._get_url(METADATA_URL + "security-groups").text.splitlines()
 
+    @property
+    def spot_instance_action(self):
+        return self._get_url(METADATA_URL + "spot/instance-action").text
+
     @cached_property
     def user_data(self):
         resp = self._get_url(USERDATA_URL, allow_404=True)


### PR DESCRIPTION
When using this library to work with "spot" instances, I ended up needing to add support for this special instance-action to read the terminate/stop states.

This seems to have been discussed in https://github.com/adamchainz/ec2-metadata/issues/201 and it was suggested to add it via PR.