### PR TITLE
Add availability-zone-id

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Add ``availability_zone_id`` attribute.
+
 2.4.0 (2021-05-13)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,13 @@ The ID of the AMI used to launch the instance, e.g. ``'ami-123456'``.
 
 The name of the current AZ e.g. ``'eu-west-1a'``.
 
+``availability_zone_id: str``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The unique, cross-account ID of the current AZ e.g. ``'use1-az6'`` -
+see `AWS docs page “AZ IDs for your AWS resources”
+<https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html>`_.
+
 ``ami_launch_index: int``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ The ID of the AMI used to launch the instance, e.g. ``'ami-123456'``.
 The name of the current AZ e.g. ``'eu-west-1a'``.
 
 ``availability_zone_id: str``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The unique, cross-account ID of the current AZ e.g. ``'use1-az6'`` -
 see `AWS docs page “AZ IDs for your AWS resources”

--- a/README.rst
+++ b/README.rst
@@ -128,9 +128,9 @@ The name of the current AZ e.g. ``'eu-west-1a'``.
 ``availability_zone_id: str``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The unique, cross-account ID of the current AZ e.g. ``'use1-az6'`` -
-see `AWS docs page “AZ IDs for your AWS resources”
-<https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html>`_.
+The unique, cross-account ID of the current AZ e.g. ``'use1-az6'``.
+See AWS docs page `AZ IDs for your AWS resources
+<https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html>`__.
 
 ``ami_launch_index: int``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ec2_metadata.py
+++ b/src/ec2_metadata.py
@@ -78,6 +78,10 @@ class EC2Metadata(BaseLazyObject):
         return self._get_url(METADATA_URL + "placement/availability-zone").text
 
     @cached_property
+    def availability_zone_id(self):
+        return self._get_url(METADATA_URL + "placement/availability-zone-id").text
+
+    @cached_property
     def ami_launch_index(self):
         return int(self._get_url(METADATA_URL + "ami-launch-index").text)
 

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -119,6 +119,13 @@ def test_availability_zone(em_requests_mock):
     assert ec2_metadata.availability_zone == "eu-west-1a"
 
 
+def test_availability_zone_id(em_requests_mock):
+    em_requests_mock.get(
+        METADATA_URL + "placement/availability-zone-id", text="use1-az6"
+    )
+    assert ec2_metadata.availability_zone == "use1-az6"
+
+
 def test_iam_info(em_requests_mock):
     em_requests_mock.get(METADATA_URL + "iam/info", text="{}")
     assert ec2_metadata.iam_info == {}

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -123,7 +123,7 @@ def test_availability_zone_id(em_requests_mock):
     em_requests_mock.get(
         METADATA_URL + "placement/availability-zone-id", text="use1-az6"
     )
-    assert ec2_metadata.availability_zone == "use1-az6"
+    assert ec2_metadata.availability_zone_id == "use1-az6"
 
 
 def test_iam_info(em_requests_mock):


### PR DESCRIPTION
The EC2 metadata service now includes `placement/availability-zone-id`, giving the unique ID of the instance’s AZ that can be compared across AWS accounts.

(`placement/region` is also now available, and could be used by this package instead of reading the instance identity document.)