### PR TITLE
Add tags attribute

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+* Add ``tags`` attribute, a mapping of the instance tags.
+  This requires the corresponding EC2 feature to be enabled on the instance.
+
+  Thanks to Renan Rodrigues in `PR #344 <https://github.com/adamchainz/ec2-metadata/pull/344>`__.
+
 2.7.0 (2022-01-10)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -352,6 +352,13 @@ The list of IPv6 CIDR blocks of the subnet in which the interface resides, e.g.
 ``['2001:db8:abcd:ef00::/64']``. If the subnet does not have any IPv6 CIDR
 blocks or the instance isn't in a VPC, the list will be empty, e.g. ``[]``.
 
+``tags: map``
+~~~~~~~~~~~~~~~~~~~
+
+The map of instance tags when it is enabled, e.g.
+``{'Name': 'my-instance'}``.
+If this is not enabled, it returns an empty map, e.g. ``{}``.
+
 ``vpc_id: str``
 ~~~~~~~~~~~~~~~
 

--- a/src/ec2_metadata/__init__.py
+++ b/src/ec2_metadata/__init__.py
@@ -185,6 +185,19 @@ class EC2Metadata(BaseLazyObject):
         return self._get_url(f"{self.metadata_url}security-groups").text.splitlines()
 
     @cached_property
+    def tags(self) -> dict[str, str]:
+        tags = {}
+
+        resp = self._get_url(f"{self.metadata_url}tags/instance/", allow_404=True)
+        if not resp.status_code == 404:
+            tags_keys = [line.rstrip("/") for line in resp.text.splitlines()]
+            for tag_key in tags_keys:
+                resp = self._get_url(f"{self.metadata_url}tags/instance/{tag_key}")
+                tag_value = resp.text
+                tags[tag_key] = tag_value
+        return tags
+
+    @cached_property
     def user_data(self) -> bytes | None:
         resp = self._get_url(self.userdata_url, allow_404=True)
         if resp.status_code == 404:

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -382,6 +382,41 @@ def test_tags_multiple(em_requests_mock):
     }
 
 
+def test_tags_repeat_access(em_requests_mock):
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/",
+        text="Name",
+    )
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/Name",
+        text="test-instance",
+    )
+
+    ec2_metadata.tags["Name"]
+    ec2_metadata.tags["Name"]
+
+    # 3 requests: api/token, tags/instance, tags/instance/Name
+    assert len(em_requests_mock.request_history) == 3
+
+
+def test_tags_iter(em_requests_mock):
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/",
+        text="Name",
+    )
+
+    assert list(iter(ec2_metadata.tags)) == ["Name"]
+
+
+def test_tags_len(em_requests_mock):
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/",
+        text="Name\ncustom-tag",
+    )
+
+    assert len(ec2_metadata.tags) == 2
+
+
 def test_user_data_none(em_requests_mock):
     em_requests_mock.get("http://169.254.169.254/latest/user-data/", status_code=404)
     assert ec2_metadata.user_data is None

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -60,6 +60,29 @@ def test_account_id(em_requests_mock):
     add_identity_doc_response(em_requests_mock, {"accountId": "1234"})
     assert ec2_metadata.account_id == "1234"
 
+def test_tags(em_requests_mock):
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/",
+        text="Name\nTest",
+    )
+
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/Name",
+        text="test-instance",
+    )
+
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/Test",
+        text="foobar",
+    )
+
+    assert ec2_metadata.tags.get('Name') == 'test-instance'
+    assert ec2_metadata.tags.get('Test') == 'foobar'
+
+def test_tags_not_enabled(em_requests_mock):
+    em_requests_mock.get("http://169.254.169.254/latest/meta-data/tags/instance/", status_code=404)
+
+    assert ec2_metadata.tags == {}
 
 def test_account_id_token_error(requests_mock):
     requests_mock.put(

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -60,6 +60,7 @@ def test_account_id(em_requests_mock):
     add_identity_doc_response(em_requests_mock, {"accountId": "1234"})
     assert ec2_metadata.account_id == "1234"
 
+
 def test_tags(em_requests_mock):
     em_requests_mock.get(
         "http://169.254.169.254/latest/meta-data/tags/instance/",
@@ -76,13 +77,17 @@ def test_tags(em_requests_mock):
         text="foobar",
     )
 
-    assert ec2_metadata.tags.get('Name') == 'test-instance'
-    assert ec2_metadata.tags.get('Test') == 'foobar'
+    assert ec2_metadata.tags.get("Name") == "test-instance"
+    assert ec2_metadata.tags.get("Test") == "foobar"
+
 
 def test_tags_not_enabled(em_requests_mock):
-    em_requests_mock.get("http://169.254.169.254/latest/meta-data/tags/instance/", status_code=404)
+    em_requests_mock.get(
+        "http://169.254.169.254/latest/meta-data/tags/instance/", status_code=404
+    )
 
     assert ec2_metadata.tags == {}
+
 
 def test_account_id_token_error(requests_mock):
     requests_mock.put(


### PR DESCRIPTION
In the issue https://github.com/adamchainz/ec2-metadata/issues/343 I mentioned that now is possible to get instance tags into the metadata.
It could be enabled or disabled according to AWS docs.
This PR is about getting this information when this is enabled and exist in the metadata