### PR TITLE
Make it possible to override the service_url via an environment variable

### DIFF
--- a/src/ec2_metadata/__init__.py
+++ b/src/ec2_metadata/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import time
+from os import getenv
 from typing import Any
 
 import requests
@@ -40,7 +41,7 @@ class EC2Metadata(BaseLazyObject):
         # Previously we used a fixed version of the service, rather than 'latest', in
         # case any backward incompatible changes were made. It seems metadata service
         # v2 only operates with 'latest' at time of writing (2020-02-12).
-        self.service_url = "http://169.254.169.254/latest/"
+        self.service_url = getenv("EC2METADATA_SERVICE_URL", "http://169.254.169.254/latest/")
         self.dynamic_url = f"{self.service_url}dynamic/"
         self.metadata_url = f"{self.service_url}meta-data/"
         self.userdata_url = f"{self.service_url}user-data/"


### PR DESCRIPTION
Provides a simple mechanism to override the `service_url` via the environment variable (`EC2METADATA_SERVICE_URL`) which in turn makes developing/experimenting with `ec2_metadata` a little easier.

For example
```
export EC2METADATA_SERVICE_URL="http://127.0.0.1:8888/latest/"
```

Which then sets us up to be able to ssh port forward to a remote AWS instance
```
ssh -L 8888:169.254.169.254:80 ec2-instance.aws.hostname
```

And thus access the remote AWS-instance ec2_metadata from a local (development) host
```
user@computer:~/ec2-metadata$ python
Python 3.8.10 (default, Nov 26 2021, 20:14:08)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>> import os
>>> os.getenv("EC2METADATA_SERVICE_URL")
'http://127.0.0.1:8888/latest/'
>>>
>>> from src.ec2_metadata import ec2_metadata
>>>
>>> ec2_metadata.ami_id
'ami-00001111222200000'
>>>
```


