### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/ec2_metadata/__init__.py
+++ b/src/ec2_metadata/__init__.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import datetime as dt
 import sys
 import time
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
+from collections.abc import Mapping
 from typing import Any
 
 import requests

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Generator
+from typing import Any
+from typing import Generator
 
 import pytest
 import requests
 from requests_mock import Mocker as RequestsMocker
 
-from ec2_metadata import (
-    TOKEN_TTL_SECONDS,
-    EC2Metadata,
-    InstanceIdentityDocumentDict,
-    NetworkInterface,
-    ec2_metadata,
-)
+from ec2_metadata import ec2_metadata
+from ec2_metadata import EC2Metadata
+from ec2_metadata import InstanceIdentityDocumentDict
+from ec2_metadata import NetworkInterface
+from ec2_metadata import TOKEN_TTL_SECONDS
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
