### PR TITLE
Add public_keys attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 
 * Add ``public_keys`` attribute and ``PublicKey`` class.
 
+  Thanks to Adam Novak in `PR #562 <https://github.com/adamchainz/ec2-metadata/pull/562>`__.
+
 2.14.0 (2024-10-27)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Add ``public_keys`` attribute and ``PublicKey`` class.
+
 2.14.0 (2024-10-27)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -489,7 +489,5 @@ Again like ``EC2Metadata`` all its attributes cache on first access, and can be 
 ``openssh_key: str | None``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The SSH public key in OpenSSH format, for example ``ssh-rsa AAAAblahblahblah= exampleuser@examplehost\n``.
-Note the presence of the trailing newline character.
-If the key is not available in OpenSSH format, this will be ``None``.
-Note that OpenSSH format is currently the only documented key format.
+The SSH public key in OpenSSH format, with a trailing newline, for example: ``ssh-rsa AAAAblahblahblah= exampleuser@examplehost\n``.
+If the key is not available in OpenSSH format, this will be ``None``, however that is unlikely as that is the only format currently supported by the metadata service.

--- a/README.rst
+++ b/README.rst
@@ -303,6 +303,14 @@ For example: ``'ec2-1-2-3-4.compute-1.amazonaws.com'``.
 The public IPv4 address of the instance, or ``None`` if the instance is not public.
 For example: ``'1.2.3.4'``.
 
+``public_keys: dict[str, PublicKey]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary of key name to ``PublicKey``, which represents data available on an SSH public key, documented below.
+These keys represent the SSH keys authorized to log into the instance when it was created.
+For example: ``{'somekey': PublicKey(0)}``
+If no public keys are available, this will be an empty dictionary.
+
 ``region: str``
 ~~~~~~~~~~~~~~~
 
@@ -471,3 +479,17 @@ If the interface doesn’t have any such CIDR blocks, the list will be empty.
 
 The list of IPv6 CIDR blocks of the VPC in which the interface resides, for example ``['2001:db8:abcd:ef00::/56']``.
 If the VPC does not have any IPv6 CIDR blocks or the instance isn't in a VPC, the list will be empty, for example ``[]``.
+
+``PublicKey``
+-------------
+
+Represents a single SSH public key, as retrieved from ``EC2Metadata.public_keys``.
+Again like ``EC2Metadata`` all its attributes cache on first access, and can be cleared with ``del`` or its ``clear_all()`` method.
+
+``openssh_key: str | None``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SSH public key in OpenSSH format, for example ``ssh-rsa AAAAblahblahblah= exampleuser@examplehost\n``.
+Note the presence of the trailing newline character.
+If the key is not available in OpenSSH format, this will be ``None``.
+Note that OpenSSH format is currently the only documented key format.

--- a/src/ec2_metadata/__init__.py
+++ b/src/ec2_metadata/__init__.py
@@ -250,7 +250,7 @@ class EC2Metadata(BaseLazyObject):
         if resp.status_code == 404:
             return {}
         pairs = [line.split("=", 1) for line in resp.text.splitlines()]
-        return {name: PublicKey(int(index), self) for index, name in pairs} 
+        return {name: PublicKey(int(index), self) for index, name in pairs}
 
     @cached_property
     def partition(self) -> str:

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -778,8 +778,11 @@ def add_key_response(
     text: str = "",
     **kwargs: Any,
 ) -> None:
-    full_url = "http://169.254.169.254/latest/meta-data/public-keys/" + str(index) + url
-    em_requests_mock.get(full_url, text=text, **kwargs)
+    em_requests_mock.get(
+        f"http://169.254.169.254/latest/meta-data/public-keys/{index}{url}",
+        text=text,
+        **kwargs,
+    )
 
 
 def test_public_key_equal():

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -405,19 +405,20 @@ def test_public_ipv4_none(em_requests_mock):
     )
     assert ec2_metadata.public_ipv4 is None
 
+
 def test_public_keys(em_requests_mock):
     em_requests_mock.get(
         "http://169.254.169.254/latest/meta-data/public-keys/", text="0=somekey"
     )
-    assert ec2_metadata.public_keys == {
-        "somekey": PublicKey(0, ec2_metadata)
-    }
+    assert ec2_metadata.public_keys == {"somekey": PublicKey(0, ec2_metadata)}
+
 
 def test_public_keys_none(em_requests_mock):
     em_requests_mock.get(
         "http://169.254.169.254/latest/meta-data/public-keys/", status_code=404
     )
     assert ec2_metadata.public_keys == {}
+
 
 def test_region(em_requests_mock):
     add_identity_doc_response(em_requests_mock, region="eu-whatever-1")
@@ -771,13 +772,13 @@ def test_network_interface_vpc_ipv6_cidr_blocks_none(em_requests_mock):
 
 
 def add_key_response(
-        em_requests_mock: RequestsMocker, index: int, url: str, text: str = "", **kwargs: Any
+    em_requests_mock: RequestsMocker,
+    index: int,
+    url: str,
+    text: str = "",
+    **kwargs: Any,
 ) -> None:
-    full_url = (
-        "http://169.254.169.254/latest/meta-data/public-keys/"
-        + str(index)
-        + url
-    )
+    full_url = "http://169.254.169.254/latest/meta-data/public-keys/" + str(index) + url
     em_requests_mock.get(full_url, text=text, **kwargs)
 
 


### PR DESCRIPTION
This adds a `public_keys` attribute to `ec2_metadata`. Like in Boto 2, it's a dictionary keyed by the human-assigned SSH key name.

Whereas Boto 2 always retrieved the `/openssh-key` field for every key and represented the key as a string (see https://github.com/boto/boto/blob/70c65b4f67af41ccfd40d21e49880be568997ba6/boto/utils.py#L261-L265), this introduces a `PublicKey` object with an `openssh_key` attribute to model the single-field object. The docs at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html document just a `public-keys/0/openssh-key` endpoint. The API structure is designed to allow for multiple keys and multiple formats, and Boto 2 already supported multiple keys, so I wrote this to support both multiple keys and multiple formats even though only `openssh-key` currently exists.

Instead of a `None` for the case where the list of keys is not available at all, I'm returning an empty dict `{}`.

I'm making an assumption that what I'm calling the "index" of a key (`0` in all of Amazon's examples) is constrained to be an integer. Right now I think Amazon only ever produces 0.

I've written tests for this that pass, and I've manually tested on an AWS instance and was able to retrieve the key. I noticed that AWS serves the key data with a trailing newline, which I'm not making any attempt to remove.

This should fix #561.